### PR TITLE
refactor: Simplify authentication logic by removing JWT verification …

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-const JWT_SECRET = process.env.JWT_SECRET || '';
-
 // Public routes that don't require authentication
 const PUBLIC_ROUTES = [
   '/api/auth/login',
@@ -19,44 +17,14 @@ function isPublicRoute(pathname: string): boolean {
   return PUBLIC_ROUTES.some(route => pathname.startsWith(route));
 }
 
-// Simple JWT verification for Edge Runtime
-async function verifyAuthToken(request: NextRequest): Promise<boolean> {
+// Simple cookie presence check for Edge Runtime
+// JWT signature validation is handled by API routes using getServerAuthState()
+async function hasAuthCookie(request: NextRequest): Promise<boolean> {
   try {
     const token = request.cookies.get('auth-token')?.value;
     
-    if (!token) {
-      return false;
-    }
-
-    if (!JWT_SECRET) {
-      return false;
-    }
-
-    // Basic JWT structure check
-    const parts = token.split('.');
-    if (parts.length !== 3) {
-      return false;
-    }
-
-    try {
-      // Decode payload (no verification for now, just check structure and expiration)
-      const payload = JSON.parse(atob(parts[1]));
-      const now = Math.floor(Date.now() / 1000);
-      
-      // Check if token has expired
-      if (payload.exp && payload.exp < now) {
-        return false;
-      }
-      
-      // Check if token has required fields
-      if (!payload.username) {
-        return false;
-      }
-      
-      return true;
-    } catch {
-      return false;
-    }
+    // Only check for cookie presence - API routes handle proper JWT validation
+    return !!token;
   } catch {
     return false;
   }
@@ -70,8 +38,8 @@ export async function middleware(request: NextRequest) {
     return NextResponse.next();
   }
 
-  // Check authentication for protected routes
-  const isAuthenticated = await verifyAuthToken(request);
+  // Check for auth cookie presence - API routes handle JWT validation
+  const isAuthenticated = await hasAuthCookie(request);
 
   if (!isAuthenticated) {
     // For API routes, return 401

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,7 +19,7 @@ function isPublicRoute(pathname: string): boolean {
 
 // Simple cookie presence check for Edge Runtime
 // JWT signature validation is handled by API routes using getServerAuthState()
-async function hasAuthCookie(request: NextRequest): Promise<boolean> {
+function hasAuthCookie(request: NextRequest): boolean {
   try {
     const token = request.cookies.get('auth-token')?.value;
     
@@ -39,7 +39,7 @@ export async function middleware(request: NextRequest) {
   }
 
   // Check for auth cookie presence - API routes handle JWT validation
-  const isAuthenticated = await hasAuthCookie(request);
+  const isAuthenticated = hasAuthCookie(request);
 
   if (!isAuthenticated) {
     // For API routes, return 401


### PR DESCRIPTION
This pull request simplifies the authentication logic in the `src/middleware.ts` file by removing JWT validation from the middleware layer and delegating it to the API routes. The middleware now only checks for the presence of the `auth-token` cookie to determine authentication status.

Authentication logic simplification:

* Removed JWT secret usage and all JWT signature and payload validation from the middleware, relying solely on the presence of the `auth-token` cookie for authentication checks. [[1]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L4-L5) [[2]](diffhunk://#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L22-R27)
* Replaced the `verifyAuthToken` function with a simpler `hasAuthCookie` function, clarifying that full JWT validation is handled by API routes using `getServerAuthState()`.
* Updated the main `middleware` function to use the new cookie-based authentication check instead of JWT validation.