### PR TITLE
fix: Remove unnecessary path trimming from N8N_WEBHOOK_BASE_URL initialization

### DIFF
--- a/src/lib/n8n-client.ts
+++ b/src/lib/n8n-client.ts
@@ -58,7 +58,7 @@ export class N8NClient {
 
   public static getInstance(): N8NClient {
     if (!N8NClient.instance) {
-      const baseUrl = process.env.N8N_WEBHOOK_BASE_URL?.replace(/\/[^/]*$/, '') || 'http://n8n:5678';
+      const baseUrl = process.env.N8N_WEBHOOK_BASE_URL || 'http://n8n:5678';
       const apiKey = process.env.N8N_API_KEY || process.env.WEBHOOK_API_KEY || '';
       
       N8NClient.instance = new N8NClient({


### PR DESCRIPTION
This pull request makes a small change to the `N8NClient` class to simplify how the `baseUrl` is determined. The unnecessary regular expression that modified the environment variable value has been removed, so now `N8N_WEBHOOK_BASE_URL` is used directly if set.

* Simplified the assignment of `baseUrl` in the `getInstance` method of `N8NClient` by removing the regular expression replacement and using the environment variable directly.