### PR TITLE
fix: Update authorization header to use 'apikey' instead of 'Authorization'

### DIFF
--- a/src/lib/n8n-client.ts
+++ b/src/lib/n8n-client.ts
@@ -74,7 +74,7 @@ export class N8NClient {
       const response = await axios.post(`${this.config.baseUrl}/webhook/${endpoint}`, data, {
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${this.config.apiKey}`
+          'apikey': this.config.apiKey
         },
         timeout: 30000 // 30 second timeout
       });


### PR DESCRIPTION
This pull request updates the authentication method used in webhook requests from the `N8NClient` class. The change replaces the use of the `Authorization` header with the `apikey` header to match the expected authentication mechanism.

Authentication header update:

* Changed the header used for API key authentication in webhook requests from `Authorization: Bearer` to `apikey`, ensuring compatibility with the target API. (`src/lib/n8n-client.ts`, [src/lib/n8n-client.tsL77-R77](diffhunk://#diff-0fb04b335f95c0ef7adddc3f2f0f511a7082175b8172757d668c4834f350cc71L77-R77))