### PR TITLE
refactor: Enhance mobile performance in StreamingMarkdownRenderer and adjust batching intervals in streaming buffer

### DIFF
--- a/src/components/StreamingMarkdownRenderer.tsx
+++ b/src/components/StreamingMarkdownRenderer.tsx
@@ -44,9 +44,9 @@ export default function StreamingMarkdownRenderer({
           <div className="flex flex-col items-center justify-center py-8 space-y-4">
             {/* Loading animation */}
             <div className="flex space-x-2">
-              <div className="w-3 h-3 bg-blue-500 rounded-full animate-bounce"></div>
-              <div className="w-3 h-3 bg-blue-500 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }}></div>
-              <div className="w-3 h-3 bg-blue-500 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }}></div>
+              <div className="w-3 h-3 bg-blue-500 rounded-full loading-dot loading-dot-1"></div>
+              <div className="w-3 h-3 bg-blue-500 rounded-full loading-dot loading-dot-2"></div>
+              <div className="w-3 h-3 bg-blue-500 rounded-full loading-dot loading-dot-3"></div>
             </div>
             
             {/* Status text */}

--- a/src/components/StreamingMarkdownRenderer.tsx
+++ b/src/components/StreamingMarkdownRenderer.tsx
@@ -9,6 +9,9 @@ import { isMobileDevice } from '@/lib/streaming-buffer';
 // Lazy load ReactMarkdown
 const ReactMarkdown = lazy(() => import('react-markdown'));
 
+// Progress estimation factor: assumes ~1000 characters represents a typical complete response
+const PROGRESS_ESTIMATION_FACTOR = 1000;
+
 interface StreamingMarkdownRendererProps {
   content: string;
   isStreaming?: boolean;
@@ -61,12 +64,12 @@ export default function StreamingMarkdownRenderer({
                   <div 
                     className="bg-blue-500 h-2 rounded-full transition-all duration-300 ease-out"
                     style={{ 
-                      width: `${Math.min(100, (content.length / 1000) * 100)}%`
+                      width: `${Math.min(100, (content.length / PROGRESS_ESTIMATION_FACTOR) * 100)}%`
                     }}
                   ></div>
                 </div>
                 <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 text-center">
-                  {Math.round((content.length / 1000) * 100)}% estimated progress
+                  {Math.round((content.length / PROGRESS_ESTIMATION_FACTOR) * 100)}% estimated progress
                 </p>
               </div>
             )}

--- a/src/lib/streaming-buffer.ts
+++ b/src/lib/streaming-buffer.ts
@@ -116,6 +116,9 @@ export const isSafari = (): boolean => {
 
 /**
  * Get optimal batching interval based on device capabilities
+ * Mobile devices use longer intervals to reduce processing overhead,
+ * but since mobile now shows a loading state instead of streaming content,
+ * we can be more conservative with updates
  */
 export const getOptimalBatchInterval = (): number => {
   if (typeof window === 'undefined') return 75;
@@ -123,10 +126,10 @@ export const getOptimalBatchInterval = (): number => {
   const mobile = isMobileDevice();
   const safari = isSafari();
   
-  // Longer intervals for mobile to reduce processing overhead
-  if (mobile && safari) return 200; // iOS Safari needs longer intervals
-  if (mobile) return 150; // Other mobile browsers
-  return 75; // Desktop default
+  // Longer intervals for mobile since content is buffered and not displayed during streaming
+  if (mobile && safari) return 300; // iOS Safari - even longer since content is hidden
+  if (mobile) return 250; // Other mobile browsers - longer intervals for better performance
+  return 75; // Desktop default - keep responsive for real-time display
 };
 
 /**

--- a/src/styles/streaming-animations.css
+++ b/src/styles/streaming-animations.css
@@ -49,9 +49,36 @@
   }
 }
 
+/* Loading dots bounce animation */
+@keyframes bounceLoading {
+  0%, 80%, 100% {
+    transform: scale(0);
+  }
+  40% {
+    transform: scale(1);
+  }
+}
+
 /* Custom classes for streaming */
 .streaming-indicator {
   animation: streamingPulse 2s ease-in-out infinite;
+}
+
+/* Loading dots with staggered animation delays */
+.loading-dot {
+  animation: bounceLoading 1.5s infinite ease-in-out;
+}
+
+.loading-dot-1 {
+  animation-delay: 0s;
+}
+
+.loading-dot-2 {
+  animation-delay: 0.15s;
+}
+
+.loading-dot-3 {
+  animation-delay: 0.3s;
 }
 
 .streaming-glow {


### PR DESCRIPTION
This pull request updates the streaming markdown rendering logic to improve mobile performance and provide a more consistent experience across devices. The main change is that mobile devices now display a loading indicator instead of streaming partial content, while desktop devices continue to show live updates. Additionally, syntax highlighting is enabled for all devices when rendering is complete, and batch intervals for streaming are adjusted for mobile browsers.

**Mobile rendering improvements:**

* Mobile devices now show a loading animation and progress indicator during streaming, hiding partial content until the response is complete for better performance. (`StreamingMarkdownRenderer.tsx`, [src/components/StreamingMarkdownRenderer.tsxL35-R86](diffhunk://#diff-1d26550ed0752443ee6b6afe0fa5351474303beac9f66e3e3f921c81015c6465L35-R86))
* Streaming batch intervals are increased for mobile browsers (especially iOS Safari) since content is buffered and not displayed, further reducing processing overhead. (`streaming-buffer.ts`, [src/lib/streaming-buffer.tsR119-R132](diffhunk://#diff-7761041c3661e87a06b9cc1e74a0940d8786f4795a623962dc00f41ffa8a9ff2R119-R132))

**Desktop and general rendering consistency:**

* Desktop devices continue to display streaming content live, with progressive rendering and syntax highlighting as before. (`StreamingMarkdownRenderer.tsx`, [[1]](diffhunk://#diff-1d26550ed0752443ee6b6afe0fa5351474303beac9f66e3e3f921c81015c6465L35-R86) [[2]](diffhunk://#diff-1d26550ed0752443ee6b6afe0fa5351474303beac9f66e3e3f921c81015c6465L69-R113)
* Syntax highlighting (`rehypeHighlight`) is now always enabled for all devices when streaming is complete, ensuring consistent markdown rendering. (`StreamingMarkdownRenderer.tsx`, [[1]](diffhunk://#diff-1d26550ed0752443ee6b6afe0fa5351474303beac9f66e3e3f921c81015c6465L55-R96) [[2]](diffhunk://#diff-1d26550ed0752443ee6b6afe0fa5351474303beac9f66e3e3f921c81015c6465L98-R135) [[3]](diffhunk://#diff-1d26550ed0752443ee6b6afe0fa5351474303beac9f66e3e3f921c81015c6465L87-R124)