### PR TITLE
refactor: Optimize mobile response handling by adjusting streaming status updates

### DIFF
--- a/src/components/SearchInterface.tsx
+++ b/src/components/SearchInterface.tsx
@@ -242,9 +242,6 @@ export default function SearchInterface() {
 
       console.log(`Mobile complete response received: ${result.message.length} characters`);
       
-      // Update status to complete before setting response
-      setStreamingStatus(StreamingStatus.COMPLETE);
-      
       // Create ServiceNowResponse object
       const mobileResponse: ServiceNowResponse = {
         message: result.message,
@@ -254,26 +251,29 @@ export default function SearchInterface() {
         status: 'done'
       };
 
-      // Clean up streaming state properly
-      cleanupStreamingState(sessionKey);
-      
+      // Set response first
       setResponse(mobileResponse);
+      
+      // Then update status and clean up streaming state
+      setStreamingStatus(StreamingStatus.COMPLETE);
       setIsLoading(false);
       setIsStreaming(false);
       setStreamingContent('');
+      
+      // Clean up streaming state last
+      cleanupStreamingState(sessionKey);
 
     } catch (error) {
       console.error('Mobile submit error:', error);
       
-      // Set error status
-      setStreamingStatus(StreamingStatus.ERROR);
-      
-      // Clean up streaming state
-      cleanupStreamingState(sessionKey);
-      
+      // Set error and clean up state
       setError(error instanceof Error ? error.message : 'An unexpected error occurred');
+      setStreamingStatus(StreamingStatus.ERROR);
       setIsLoading(false);
       setIsStreaming(false);
+      
+      // Clean up streaming state last
+      cleanupStreamingState(sessionKey);
     }
   };
 


### PR DESCRIPTION
This pull request updates the order of state updates and cleanup logic in the mobile response and error handling flow of the `SearchInterface` component. The changes ensure that the response is set before status updates and cleanup, and that cleanup is consistently performed last. This helps prevent potential race conditions and ensures a more predictable UI state.

Improvements to streaming response and error handling:

* In the mobile response handler, the response is now set before updating the streaming status and cleaning up streaming state, ensuring that UI updates occur in the correct order. (`src/components/SearchInterface.tsx`, [[1]](diffhunk://#diff-48b3215164f09e4b4a64dfa0f7bfc6868314fb07580d06f1ca2068c29aecf395L245-L247) [[2]](diffhunk://#diff-48b3215164f09e4b4a64dfa0f7bfc6868314fb07580d06f1ca2068c29aecf395L257-R276)
* In the error handler, the error message and streaming status are set before cleanup, and cleanup is performed last for consistency. (`src/components/SearchInterface.tsx`, [src/components/SearchInterface.tsxL257-R276](diffhunk://#diff-48b3215164f09e4b4a64dfa0f7bfc6868314fb07580d06f1ca2068c29aecf395L257-R276))