### PR TITLE
feat: Add AgentToolBlock component and integrate with markdown rendering

### DIFF
--- a/src/components/AgentToolBlock.tsx
+++ b/src/components/AgentToolBlock.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { Copy, Check, Hammer, Code, Eye } from 'lucide-react';
+
+import { useSettings } from '@/contexts/SettingsContext';
+
+interface AgentToolBlockProps {
+  children: React.ReactNode;
+  rawMarkdown?: string;
+}
+
+// Custom comparison function for React.memo
+const arePropsEqual = (prevProps: AgentToolBlockProps, nextProps: AgentToolBlockProps): boolean => {
+  return prevProps.rawMarkdown === nextProps.rawMarkdown && prevProps.children === nextProps.children;
+};
+
+const AgentToolBlock = React.memo(({ children, rawMarkdown = '' }: AgentToolBlockProps) => {
+  const [copied, setCopied] = useState(false);
+  const { settings, updateSetting } = useSettings();
+  const [displayMode, setDisplayMode] = useState<'raw' | 'styled'>(
+    settings.agent_tool_block_display_mode || 'styled'
+  );
+
+  // Sync local state with settings changes
+  useEffect(() => {
+    setDisplayMode(settings.agent_tool_block_display_mode || 'styled');
+  }, [settings.agent_tool_block_display_mode]);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(rawMarkdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy agent tool:', err);
+    }
+  };
+
+  const handleToggleDisplay = async () => {
+    const newMode = displayMode === 'raw' ? 'styled' : 'raw';
+    // Update local state immediately for instant UI feedback
+    setDisplayMode(newMode);
+
+    try {
+      await updateSetting('agent_tool_block_display_mode', newMode);
+    } catch (err) {
+      console.error('Failed to update display mode:', err);
+      // Revert on error
+      setDisplayMode(displayMode);
+    }
+  };
+
+  return (
+    <div className="relative my-4">
+      <div className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-xl rounded-2xl shadow-lg shadow-orange-500/10 dark:shadow-orange-500/20 border border-orange-200/50 dark:border-orange-700/50 overflow-hidden transition-all duration-200 hover:shadow-xl hover:shadow-orange-500/20">
+        {/* Header with Hammer Icon and Action Buttons */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-orange-50 to-amber-50 dark:from-orange-900/30 dark:to-amber-900/30 border-b border-orange-200/50 dark:border-orange-700/50">
+          <div className="flex items-center gap-2">
+            <Hammer className="w-4 h-4 text-orange-600 dark:text-orange-400 flex-shrink-0" />
+            <span className="text-sm font-medium text-orange-800 dark:text-orange-300">
+              Agent Tool
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleDisplay}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title={displayMode === 'raw' ? 'Show styled markdown' : 'Show raw text'}
+              aria-label={displayMode === 'raw' ? 'Switch to styled markdown view' : 'Switch to raw text view'}
+            >
+              {displayMode === 'raw' ? (
+                <>
+                  <Eye className="w-3.5 h-3.5" />
+                  Styled
+                </>
+              ) : (
+                <>
+                  <Code className="w-3.5 h-3.5" />
+                  Raw
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title="Copy agent tool"
+              aria-label="Copy agent tool to clipboard"
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3.5 h-3.5" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Content Area */}
+        <div className="p-4 sm:p-6 bg-gray-50 dark:bg-gray-800">
+          {displayMode === 'raw' ? (
+            <pre
+              className="text-sm sm:text-base leading-relaxed overflow-x-auto whitespace-pre-wrap text-gray-800 dark:text-gray-200"
+              style={{
+                fontFamily: "'SF Mono', 'Monaco', 'Consolas', 'Liberation Mono', monospace",
+                WebkitOverflowScrolling: 'touch'
+              }}
+            >
+              {rawMarkdown}
+            </pre>
+          ) : (
+            <div className="text-sm sm:text-base leading-relaxed overflow-x-auto text-gray-800 dark:text-gray-200">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}, arePropsEqual);
+
+AgentToolBlock.displayName = 'AgentToolBlock';
+
+export default AgentToolBlock;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -91,6 +91,7 @@ export interface UserSettings {
   selected_provider_id?: number; // New field: selected provider for filtering models
   visible_request_types?: ('documentation' | 'recommendation' | 'script' | 'troubleshoot' | 'ai-agent')[]; // New field: modes to show in UI
   agent_block_display_mode?: 'raw' | 'styled'; // New field: how to display agent block content (default: 'raw')
+  agent_tool_block_display_mode?: 'raw' | 'styled'; // New field: how to display agent tool block content (default: 'styled')
 }
 
 export interface Capability {


### PR DESCRIPTION
This pull request introduces a new `AgentToolBlock` React component and integrates it into the markdown rendering pipeline, allowing agent tool containers in markdown to be displayed with enhanced UI and user controls. The changes also add support for user settings to control the display mode of agent tool blocks, and improve the caching and extraction logic for container content in markdown.

**New UI Component and Markdown Integration:**

* Added the new `AgentToolBlock` component in `src/components/AgentToolBlock.tsx`, featuring a styled container with copy-to-clipboard functionality, display mode toggling (raw/styled), and integration with user settings.
* Integrated `AgentToolBlock` into the markdown renderer in `src/lib/markdown-components.tsx`, so markdown containers of type `agent-tool` are rendered with this component and receive their raw markdown content. [[1]](diffhunk://#diff-7f9f30600e662157dc1e5f865e5832f7a1d939bac729dc7097826828fe3fcf18R6) [[2]](diffhunk://#diff-7f9f30600e662157dc1e5f865e5832f7a1d939bac729dc7097826828fe3fcf18R190-L184)

**Caching and Extraction Improvements:**

* Enhanced the container content extraction cache in `src/lib/markdown-components.tsx` to track the index of each container type, ensuring correct mapping of raw markdown to the corresponding block instance. [[1]](diffhunk://#diff-7f9f30600e662157dc1e5f865e5832f7a1d939bac729dc7097826828fe3fcf18R18-R20) [[2]](diffhunk://#diff-7f9f30600e662157dc1e5f865e5832f7a1d939bac729dc7097826828fe3fcf18R151-R167)

**User Settings Support:**

* Added a new `agent_tool_block_display_mode` field to the `UserSettings` interface in `src/types/index.ts`, enabling users to choose how agent tool blocks are displayed (raw or styled).