### PR TITLE
feat: Add new skill and tool blocks for enhanced markdown rendering

### DIFF
--- a/src/components/PromptBlock.tsx
+++ b/src/components/PromptBlock.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Copy, Check, MessageSquare, Code, Eye } from 'lucide-react';
+
+interface PromptBlockProps {
+  children: React.ReactNode;
+  rawMarkdown?: string;
+}
+
+// Custom comparison function for React.memo
+const arePropsEqual = (prevProps: PromptBlockProps, nextProps: PromptBlockProps): boolean => {
+  return prevProps.rawMarkdown === nextProps.rawMarkdown && prevProps.children === nextProps.children;
+};
+
+const PromptBlock = React.memo(({ children, rawMarkdown = '' }: PromptBlockProps) => {
+  const [copied, setCopied] = useState(false);
+  const [displayMode, setDisplayMode] = useState<'raw' | 'styled'>('styled');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(rawMarkdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy prompt:', err);
+    }
+  };
+
+  const handleToggleDisplay = () => {
+    setDisplayMode(displayMode === 'raw' ? 'styled' : 'raw');
+  };
+
+  return (
+    <div className="relative my-4">
+      <div className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-xl rounded-2xl shadow-lg shadow-indigo-500/10 dark:shadow-indigo-500/20 border border-indigo-200/50 dark:border-indigo-700/50 overflow-hidden transition-all duration-200 hover:shadow-xl hover:shadow-indigo-500/20">
+        {/* Header with MessageSquare Icon and Action Buttons */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-indigo-50 to-violet-50 dark:from-indigo-900/30 dark:to-violet-900/30 border-b border-indigo-200/50 dark:border-indigo-700/50">
+          <div className="flex items-center gap-2">
+            <MessageSquare className="w-4 h-4 text-indigo-600 dark:text-indigo-400 flex-shrink-0" />
+            <span className="text-sm font-medium text-indigo-800 dark:text-indigo-300">
+              Prompt
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleDisplay}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title={displayMode === 'raw' ? 'Show styled markdown' : 'Show raw text'}
+              aria-label={displayMode === 'raw' ? 'Switch to styled markdown view' : 'Switch to raw text view'}
+            >
+              {displayMode === 'raw' ? (
+                <>
+                  <Eye className="w-3.5 h-3.5" />
+                  Styled
+                </>
+              ) : (
+                <>
+                  <Code className="w-3.5 h-3.5" />
+                  Raw
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title="Copy prompt"
+              aria-label="Copy prompt to clipboard"
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3.5 h-3.5" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Content Area */}
+        <div className="p-4 sm:p-6 bg-gray-50 dark:bg-gray-800">
+          {displayMode === 'raw' ? (
+            <pre
+              className="text-sm sm:text-base leading-relaxed overflow-x-auto whitespace-pre-wrap text-gray-800 dark:text-gray-200"
+              style={{
+                fontFamily: "'SF Mono', 'Monaco', 'Consolas', 'Liberation Mono', monospace",
+                WebkitOverflowScrolling: 'touch'
+              }}
+            >
+              {rawMarkdown}
+            </pre>
+          ) : (
+            <div className="text-sm sm:text-base leading-relaxed overflow-x-auto text-gray-800 dark:text-gray-200">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}, arePropsEqual);
+
+PromptBlock.displayName = 'PromptBlock';
+
+export default PromptBlock;

--- a/src/components/SkillConfigurationBlock.tsx
+++ b/src/components/SkillConfigurationBlock.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Copy, Check, Settings, Code, Eye } from 'lucide-react';
+
+interface SkillConfigurationBlockProps {
+  children: React.ReactNode;
+  rawMarkdown?: string;
+}
+
+// Custom comparison function for React.memo
+const arePropsEqual = (prevProps: SkillConfigurationBlockProps, nextProps: SkillConfigurationBlockProps): boolean => {
+  return prevProps.rawMarkdown === nextProps.rawMarkdown && prevProps.children === nextProps.children;
+};
+
+const SkillConfigurationBlock = React.memo(({ children, rawMarkdown = '' }: SkillConfigurationBlockProps) => {
+  const [copied, setCopied] = useState(false);
+  const [displayMode, setDisplayMode] = useState<'raw' | 'styled'>('styled');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(rawMarkdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy skill configuration:', err);
+    }
+  };
+
+  const handleToggleDisplay = () => {
+    setDisplayMode(displayMode === 'raw' ? 'styled' : 'raw');
+  };
+
+  return (
+    <div className="relative my-4">
+      <div className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-xl rounded-2xl shadow-lg shadow-cyan-500/10 dark:shadow-cyan-500/20 border border-cyan-200/50 dark:border-cyan-700/50 overflow-hidden transition-all duration-200 hover:shadow-xl hover:shadow-cyan-500/20">
+        {/* Header with Settings Icon and Action Buttons */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-cyan-50 to-teal-50 dark:from-cyan-900/30 dark:to-teal-900/30 border-b border-cyan-200/50 dark:border-cyan-700/50">
+          <div className="flex items-center gap-2">
+            <Settings className="w-4 h-4 text-cyan-600 dark:text-cyan-400 flex-shrink-0" />
+            <span className="text-sm font-medium text-cyan-800 dark:text-cyan-300">
+              Skill Configuration
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleDisplay}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title={displayMode === 'raw' ? 'Show styled markdown' : 'Show raw text'}
+              aria-label={displayMode === 'raw' ? 'Switch to styled markdown view' : 'Switch to raw text view'}
+            >
+              {displayMode === 'raw' ? (
+                <>
+                  <Eye className="w-3.5 h-3.5" />
+                  Styled
+                </>
+              ) : (
+                <>
+                  <Code className="w-3.5 h-3.5" />
+                  Raw
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title="Copy skill configuration"
+              aria-label="Copy skill configuration to clipboard"
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3.5 h-3.5" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Content Area */}
+        <div className="p-4 sm:p-6 bg-gray-50 dark:bg-gray-800">
+          {displayMode === 'raw' ? (
+            <pre
+              className="text-sm sm:text-base leading-relaxed overflow-x-auto whitespace-pre-wrap text-gray-800 dark:text-gray-200"
+              style={{
+                fontFamily: "'SF Mono', 'Monaco', 'Consolas', 'Liberation Mono', monospace",
+                WebkitOverflowScrolling: 'touch'
+              }}
+            >
+              {rawMarkdown}
+            </pre>
+          ) : (
+            <div className="text-sm sm:text-base leading-relaxed overflow-x-auto text-gray-800 dark:text-gray-200">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}, arePropsEqual);
+
+SkillConfigurationBlock.displayName = 'SkillConfigurationBlock';
+
+export default SkillConfigurationBlock;

--- a/src/components/SkillInputsBlock.tsx
+++ b/src/components/SkillInputsBlock.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Copy, Check, ArrowDownToLine, Code, Eye } from 'lucide-react';
+
+interface SkillInputsBlockProps {
+  children: React.ReactNode;
+  rawMarkdown?: string;
+}
+
+// Custom comparison function for React.memo
+const arePropsEqual = (prevProps: SkillInputsBlockProps, nextProps: SkillInputsBlockProps): boolean => {
+  return prevProps.rawMarkdown === nextProps.rawMarkdown && prevProps.children === nextProps.children;
+};
+
+const SkillInputsBlock = React.memo(({ children, rawMarkdown = '' }: SkillInputsBlockProps) => {
+  const [copied, setCopied] = useState(false);
+  const [displayMode, setDisplayMode] = useState<'raw' | 'styled'>('styled');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(rawMarkdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy skill inputs:', err);
+    }
+  };
+
+  const handleToggleDisplay = () => {
+    setDisplayMode(displayMode === 'raw' ? 'styled' : 'raw');
+  };
+
+  return (
+    <div className="relative my-4">
+      <div className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-xl rounded-2xl shadow-lg shadow-green-500/10 dark:shadow-green-500/20 border border-green-200/50 dark:border-green-700/50 overflow-hidden transition-all duration-200 hover:shadow-xl hover:shadow-green-500/20">
+        {/* Header with ArrowDownToLine Icon and Action Buttons */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-green-50 to-emerald-50 dark:from-green-900/30 dark:to-emerald-900/30 border-b border-green-200/50 dark:border-green-700/50">
+          <div className="flex items-center gap-2">
+            <ArrowDownToLine className="w-4 h-4 text-green-600 dark:text-green-400 flex-shrink-0" />
+            <span className="text-sm font-medium text-green-800 dark:text-green-300">
+              Skill Inputs
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleDisplay}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title={displayMode === 'raw' ? 'Show styled markdown' : 'Show raw text'}
+              aria-label={displayMode === 'raw' ? 'Switch to styled markdown view' : 'Switch to raw text view'}
+            >
+              {displayMode === 'raw' ? (
+                <>
+                  <Eye className="w-3.5 h-3.5" />
+                  Styled
+                </>
+              ) : (
+                <>
+                  <Code className="w-3.5 h-3.5" />
+                  Raw
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title="Copy skill inputs"
+              aria-label="Copy skill inputs to clipboard"
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3.5 h-3.5" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Content Area */}
+        <div className="p-4 sm:p-6 bg-gray-50 dark:bg-gray-800">
+          {displayMode === 'raw' ? (
+            <pre
+              className="text-sm sm:text-base leading-relaxed overflow-x-auto whitespace-pre-wrap text-gray-800 dark:text-gray-200"
+              style={{
+                fontFamily: "'SF Mono', 'Monaco', 'Consolas', 'Liberation Mono', monospace",
+                WebkitOverflowScrolling: 'touch'
+              }}
+            >
+              {rawMarkdown}
+            </pre>
+          ) : (
+            <div className="text-sm sm:text-base leading-relaxed overflow-x-auto text-gray-800 dark:text-gray-200">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}, arePropsEqual);
+
+SkillInputsBlock.displayName = 'SkillInputsBlock';
+
+export default SkillInputsBlock;

--- a/src/components/SkillOutputsBlock.tsx
+++ b/src/components/SkillOutputsBlock.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Copy, Check, ArrowUpFromLine, Code, Eye } from 'lucide-react';
+
+interface SkillOutputsBlockProps {
+  children: React.ReactNode;
+  rawMarkdown?: string;
+}
+
+// Custom comparison function for React.memo
+const arePropsEqual = (prevProps: SkillOutputsBlockProps, nextProps: SkillOutputsBlockProps): boolean => {
+  return prevProps.rawMarkdown === nextProps.rawMarkdown && prevProps.children === nextProps.children;
+};
+
+const SkillOutputsBlock = React.memo(({ children, rawMarkdown = '' }: SkillOutputsBlockProps) => {
+  const [copied, setCopied] = useState(false);
+  const [displayMode, setDisplayMode] = useState<'raw' | 'styled'>('styled');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(rawMarkdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy skill outputs:', err);
+    }
+  };
+
+  const handleToggleDisplay = () => {
+    setDisplayMode(displayMode === 'raw' ? 'styled' : 'raw');
+  };
+
+  return (
+    <div className="relative my-4">
+      <div className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-xl rounded-2xl shadow-lg shadow-blue-500/10 dark:shadow-blue-500/20 border border-blue-200/50 dark:border-blue-700/50 overflow-hidden transition-all duration-200 hover:shadow-xl hover:shadow-blue-500/20">
+        {/* Header with ArrowUpFromLine Icon and Action Buttons */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-blue-50 to-sky-50 dark:from-blue-900/30 dark:to-sky-900/30 border-b border-blue-200/50 dark:border-blue-700/50">
+          <div className="flex items-center gap-2">
+            <ArrowUpFromLine className="w-4 h-4 text-blue-600 dark:text-blue-400 flex-shrink-0" />
+            <span className="text-sm font-medium text-blue-800 dark:text-blue-300">
+              Skill Outputs
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleDisplay}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title={displayMode === 'raw' ? 'Show styled markdown' : 'Show raw text'}
+              aria-label={displayMode === 'raw' ? 'Switch to styled markdown view' : 'Switch to raw text view'}
+            >
+              {displayMode === 'raw' ? (
+                <>
+                  <Eye className="w-3.5 h-3.5" />
+                  Styled
+                </>
+              ) : (
+                <>
+                  <Code className="w-3.5 h-3.5" />
+                  Raw
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title="Copy skill outputs"
+              aria-label="Copy skill outputs to clipboard"
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3.5 h-3.5" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Content Area */}
+        <div className="p-4 sm:p-6 bg-gray-50 dark:bg-gray-800">
+          {displayMode === 'raw' ? (
+            <pre
+              className="text-sm sm:text-base leading-relaxed overflow-x-auto whitespace-pre-wrap text-gray-800 dark:text-gray-200"
+              style={{
+                fontFamily: "'SF Mono', 'Monaco', 'Consolas', 'Liberation Mono', monospace",
+                WebkitOverflowScrolling: 'touch'
+              }}
+            >
+              {rawMarkdown}
+            </pre>
+          ) : (
+            <div className="text-sm sm:text-base leading-relaxed overflow-x-auto text-gray-800 dark:text-gray-200">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}, arePropsEqual);
+
+SkillOutputsBlock.displayName = 'SkillOutputsBlock';
+
+export default SkillOutputsBlock;

--- a/src/components/ToolNodeBlock.tsx
+++ b/src/components/ToolNodeBlock.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Copy, Check, Hammer, Code, Eye } from 'lucide-react';
+
+interface ToolNodeBlockProps {
+  children: React.ReactNode;
+  rawMarkdown?: string;
+}
+
+// Custom comparison function for React.memo
+const arePropsEqual = (prevProps: ToolNodeBlockProps, nextProps: ToolNodeBlockProps): boolean => {
+  return prevProps.rawMarkdown === nextProps.rawMarkdown && prevProps.children === nextProps.children;
+};
+
+const ToolNodeBlock = React.memo(({ children, rawMarkdown = '' }: ToolNodeBlockProps) => {
+  const [copied, setCopied] = useState(false);
+  const [displayMode, setDisplayMode] = useState<'raw' | 'styled'>('styled');
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(rawMarkdown);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy tool node:', err);
+    }
+  };
+
+  const handleToggleDisplay = () => {
+    setDisplayMode(displayMode === 'raw' ? 'styled' : 'raw');
+  };
+
+  return (
+    <div className="relative my-4">
+      <div className="bg-white/95 dark:bg-gray-800/95 backdrop-blur-xl rounded-2xl shadow-lg shadow-yellow-500/10 dark:shadow-yellow-500/20 border border-yellow-200/50 dark:border-yellow-700/50 overflow-hidden transition-all duration-200 hover:shadow-xl hover:shadow-yellow-500/20">
+        {/* Header with Hammer Icon and Action Buttons */}
+        <div className="flex items-center justify-between px-4 py-3 bg-gradient-to-r from-yellow-50 to-amber-50 dark:from-yellow-900/30 dark:to-amber-900/30 border-b border-yellow-200/50 dark:border-yellow-700/50">
+          <div className="flex items-center gap-2">
+            <Hammer className="w-4 h-4 text-yellow-600 dark:text-yellow-400 flex-shrink-0" />
+            <span className="text-sm font-medium text-yellow-800 dark:text-yellow-300">
+              Tool Node
+            </span>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleDisplay}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title={displayMode === 'raw' ? 'Show styled markdown' : 'Show raw text'}
+              aria-label={displayMode === 'raw' ? 'Switch to styled markdown view' : 'Switch to raw text view'}
+            >
+              {displayMode === 'raw' ? (
+                <>
+                  <Eye className="w-3.5 h-3.5" />
+                  Styled
+                </>
+              ) : (
+                <>
+                  <Code className="w-3.5 h-3.5" />
+                  Raw
+                </>
+              )}
+            </button>
+
+            <button
+              onClick={handleCopy}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-white/95 dark:bg-gray-800/95 text-gray-700 dark:text-gray-200 text-xs font-medium rounded-full shadow-sm border border-gray-200/60 dark:border-gray-600/60 backdrop-blur-sm hover:bg-white dark:hover:bg-gray-700 hover:shadow-md transition-all duration-200 hover:scale-105 active:scale-95"
+              title="Copy tool node"
+              aria-label="Copy tool node to clipboard"
+            >
+              {copied ? (
+                <>
+                  <Check className="w-3.5 h-3.5" />
+                  Copied!
+                </>
+              ) : (
+                <>
+                  <Copy className="w-3.5 h-3.5" />
+                  Copy
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+
+        {/* Content Area */}
+        <div className="p-4 sm:p-6 bg-gray-50 dark:bg-gray-800">
+          {displayMode === 'raw' ? (
+            <pre
+              className="text-sm sm:text-base leading-relaxed overflow-x-auto whitespace-pre-wrap text-gray-800 dark:text-gray-200"
+              style={{
+                fontFamily: "'SF Mono', 'Monaco', 'Consolas', 'Liberation Mono', monospace",
+                WebkitOverflowScrolling: 'touch'
+              }}
+            >
+              {rawMarkdown}
+            </pre>
+          ) : (
+            <div className="text-sm sm:text-base leading-relaxed overflow-x-auto text-gray-800 dark:text-gray-200">
+              {children}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}, arePropsEqual);
+
+ToolNodeBlock.displayName = 'ToolNodeBlock';
+
+export default ToolNodeBlock;

--- a/src/lib/markdown-components.tsx
+++ b/src/lib/markdown-components.tsx
@@ -4,6 +4,12 @@ import CodeBlock from '@/components/CodeBlock';
 import StepGuide, { parseStepSequence } from '@/components/StepGuide';
 import AgentBlock from '@/components/AgentBlock';
 import AgentToolBlock from '@/components/AgentToolBlock';
+import SkillConfigurationBlock from '@/components/SkillConfigurationBlock';
+import SkillInputsBlock from '@/components/SkillInputsBlock';
+import ToolNodeBlock from '@/components/ToolNodeBlock';
+import SkillOutputsBlock from '@/components/SkillOutputsBlock';
+import PromptBlock from '@/components/PromptBlock';
+
 import { extractContainerContent } from './markdown-utils';
 
 // Cache for extracted container content to avoid re-running regex on every render
@@ -195,10 +201,47 @@ export const createMarkdownComponents = (isStreaming?: boolean, fullContent?: st
         );
       }
 
-      // Future container types can be added here:
-      // if (containerType === 'agent-description') {
-      //   return <AgentDescriptionBlock rawMarkdown={rawMarkdown} {...props}>{children}</AgentDescriptionBlock>;
-      // }
+      if (containerType === 'skill-configuration') {
+        return (
+          <SkillConfigurationBlock rawMarkdown={rawMarkdown} {...props}>
+            {children}
+          </SkillConfigurationBlock>
+        );
+      }
+
+      if (containerType === 'skill-inputs') {
+        return (
+          <SkillInputsBlock rawMarkdown={rawMarkdown} {...props}>
+            {children}
+          </SkillInputsBlock>
+        );
+      }
+
+      if (containerType === 'tool-node') {
+        return (
+          <ToolNodeBlock rawMarkdown={rawMarkdown} {...props}>
+            {children}
+          </ToolNodeBlock>
+        );
+      }
+
+      if (containerType === 'skill-outputs') {
+        return (
+          <SkillOutputsBlock rawMarkdown={rawMarkdown} {...props}>
+            {children}
+          </SkillOutputsBlock>
+        );
+      }
+
+      if (containerType === 'prompt') {
+        return (
+          <PromptBlock rawMarkdown={rawMarkdown} {...props}>
+            {children}
+          </PromptBlock>
+        );
+      }
+
+      // Future container types can be added here
 
       // Default: pass rawMarkdown as data attribute for future use
       return (


### PR DESCRIPTION
This pull request introduces several new reusable React components for rendering different types of content blocks with consistent styling and interactive features, such as toggling between raw and styled views and copying content to the clipboard. These components are then imported into the markdown rendering pipeline for use throughout the application.

Component additions:

* Added `PromptBlock`, `SkillConfigurationBlock`, `SkillInputsBlock`, `SkillOutputsBlock`, and `ToolNodeBlock` components. Each provides a styled container with a header, icon, toggle for raw/styled markdown views, and a copy-to-clipboard button. These components use `React.memo` with a custom comparison function for performance optimization. [[1]](diffhunk://#diff-8c262c2b6c49b1033190a27c9964cb81686b37cc67cb225487ca5c9cd8bc207aR1-R112) [[2]](diffhunk://#diff-1cce2fd7a4ff43df52e155012c9945850b61f910afaa279f129cfdc234a8b756R1-R112) [[3]](diffhunk://#diff-df0577abd94b26149f177364778eec4cda021ae3a1e428c54169ceecfdaef5a0R1-R112) [[4]](diffhunk://#diff-ce3bebb85b12cd8328ad1f3a7b1308b91c4a89c487405bf0468b125f733409a2R1-R112) [[5]](diffhunk://#diff-512a2cd1da7e141711f69d4d21feda05acb1bfc6eeff462370ae46c2d2cdde1dR1-R112)

Integration into markdown system:

* Imported the new block components (`PromptBlock`, `SkillConfigurationBlock`, `SkillInputsBlock`, `SkillOutputsBlock`, `ToolNodeBlock`) into `src/lib/markdown-components.tsx` for use in the markdown rendering pipeline.