### PR TITLE
feat: Update allowed agents in request validation to include new agent models

### DIFF
--- a/src/lib/request-validation.ts
+++ b/src/lib/request-validation.ts
@@ -14,7 +14,7 @@ export function validateRequest(body: StreamingRequest): string | null {
         return 'Either aiModel or agentModels with at least one agent configuration must be provided';
     }
     if (body.agentModels) {
-        const allowedAgents = ['orchestration', 'business_rule', 'client_script', 'script_include'];
+        const allowedAgents = ['orchestration', 'planner_large', 'planner_small', 'coder_large', 'coder_small', 'architect_large', 'architect_small', 'process_sme_large', 'process_sme_small'];
         for (const agentModel of body.agentModels) {
             if (!agentModel.agent || !agentModel.model) {
                 return 'Each agent configuration must have both agent and model properties';


### PR DESCRIPTION
This pull request updates the allowed agent types in the request validation logic to support a broader and more granular set of agent models. This ensures that requests can specify new agent types and configurations as the system evolves.

**Request validation updates:**

* Expanded the `allowedAgents` list in `validateRequest` (in `src/lib/request-validation.ts`) to include new agent types such as `planner_large`, `planner_small`, `coder_large`, `coder_small`, `architect_large`, `architect_small`, `process_sme_large`, and `process_sme_small`, replacing the previous limited set.